### PR TITLE
Daryl duplicate task

### DIFF
--- a/src/main/java/seedu/sherpass/Main.java
+++ b/src/main/java/seedu/sherpass/Main.java
@@ -40,7 +40,7 @@ public class Main {
             ui.showToUser(ERROR_IO_FAILURE_MESSAGE);
             System.exit(1);
         } catch (InvalidInputException | JSONException e) {
-            System.out.println(e.getMessage());
+            ui.showToUser(e.getMessage());
             storage.handleCorruptedSave(ui);
             taskList = new TaskList();
         }

--- a/src/main/java/seedu/sherpass/Main.java
+++ b/src/main/java/seedu/sherpass/Main.java
@@ -40,6 +40,7 @@ public class Main {
             ui.showToUser(ERROR_IO_FAILURE_MESSAGE);
             System.exit(1);
         } catch (InvalidInputException | JSONException e) {
+            System.out.println(e.getMessage());
             storage.handleCorruptedSave(ui);
             taskList = new TaskList();
         }

--- a/src/main/java/seedu/sherpass/constant/Message.java
+++ b/src/main/java/seedu/sherpass/constant/Message.java
@@ -55,4 +55,6 @@ public class Message {
     public static final String ERROR_INVALID_MARKING_INDEX_MESSAGE = "Bzzt!\nPlease"
             + " key in a valid task number to mark/unmark your task."
             + HELP_MESSAGE_SPECIFIC_COMMAND;
+    public static final String ERROR_DUPLICATE_TASK_MESSAGE_1 = "Skipping task \"";
+    public static final String ERROR_DUPLICATE_TASK_MESSAGE_2 = "\" as it already exists!";
 }

--- a/src/main/java/seedu/sherpass/constant/Message.java
+++ b/src/main/java/seedu/sherpass/constant/Message.java
@@ -46,7 +46,7 @@ public class Message {
             + "trying to processing the system.\n"
             + "Please reboot and execute the application again.";
     public static final String ERROR_CORRUPT_SAVED_FILE_MESSAGE_1 = "Oops! It seems that your saved file "
-            + "was corrupted.";
+            + "is corrupted.";
     public static final String ERROR_CORRUPT_SAVED_FILE_MESSAGE_2 = "Would you like to start with a new save "
             + "file? (Y/N):";
     public static final String ERROR_CORRUPT_SAVED_FILE_MESSAGE_3 = "We're sorry this happened. "

--- a/src/main/java/seedu/sherpass/exception/InvalidInputException.java
+++ b/src/main/java/seedu/sherpass/exception/InvalidInputException.java
@@ -1,4 +1,12 @@
 package seedu.sherpass.exception;
 
 public class InvalidInputException extends Exception {
+
+    public InvalidInputException(String message) {
+        super(message);
+    }
+
+    public InvalidInputException() {
+
+    }
 }

--- a/src/main/java/seedu/sherpass/util/Parser.java
+++ b/src/main/java/seedu/sherpass/util/Parser.java
@@ -74,14 +74,14 @@ public class Parser {
             if (!doOnDateString.equals("null")) {
                 doOnDate = LocalDate.parse(doOnDateString, parseFormat);
             }
-            String status = taskData.getString("status");
             parsedTask = new Task(description, byDate, doOnDate);
+            String status = taskData.getString("status");
             if (status.equals("X")) {
                 parsedTask.markAsDone();
             }
             return parsedTask;
         } catch (JSONException | DateTimeParseException exception) {
-            throw new InvalidInputException();
+            throw new InvalidInputException(exception.getMessage());
         }
     }
 

--- a/src/main/java/seedu/sherpass/util/Storage.java
+++ b/src/main/java/seedu/sherpass/util/Storage.java
@@ -22,8 +22,8 @@ import static seedu.sherpass.constant.Message.ERROR_CORRUPT_SAVED_FILE_MESSAGE_2
 import static seedu.sherpass.constant.Message.ERROR_CORRUPT_SAVED_FILE_MESSAGE_3;
 import static seedu.sherpass.constant.Message.ERROR_DUPLICATE_TASK_MESSAGE_1;
 import static seedu.sherpass.constant.Message.ERROR_DUPLICATE_TASK_MESSAGE_2;
-
 import static seedu.sherpass.constant.Message.ERROR_IO_FAILURE_MESSAGE;
+
 import static seedu.sherpass.constant.DateAndTimeFormat.parseFormat;
 
 

--- a/src/main/java/seedu/sherpass/util/Storage.java
+++ b/src/main/java/seedu/sherpass/util/Storage.java
@@ -20,6 +20,9 @@ import static seedu.sherpass.constant.Index.DIRECTORY_INDEX;
 import static seedu.sherpass.constant.Message.ERROR_CORRUPT_SAVED_FILE_MESSAGE_1;
 import static seedu.sherpass.constant.Message.ERROR_CORRUPT_SAVED_FILE_MESSAGE_2;
 import static seedu.sherpass.constant.Message.ERROR_CORRUPT_SAVED_FILE_MESSAGE_3;
+import static seedu.sherpass.constant.Message.ERROR_DUPLICATE_TASK_MESSAGE_1;
+import static seedu.sherpass.constant.Message.ERROR_DUPLICATE_TASK_MESSAGE_2;
+
 import static seedu.sherpass.constant.Message.ERROR_IO_FAILURE_MESSAGE;
 import static seedu.sherpass.constant.DateAndTimeFormat.parseFormat;
 
@@ -118,10 +121,25 @@ public class Storage {
 
             for (int i = 0; i < array.length(); i++) {
                 JSONObject taskData = array.getJSONObject(i);
-                taskList.add(Parser.parseSavedData(taskData));
+                Task newTask = Parser.parseSavedData(taskData);
+                if (!isDuplicateTask(taskList, newTask.getDescription())) {
+                    taskList.add(newTask);
+                } else {
+                    System.out.println(ERROR_DUPLICATE_TASK_MESSAGE_1 + newTask.getDescription()
+                        + ERROR_DUPLICATE_TASK_MESSAGE_2);
+                }
             }
         }
         return taskList;
+    }
+
+    private boolean isDuplicateTask(ArrayList<Task> tasks, String description) {
+        for (Task t : tasks) {
+            if (t.getDescription().equals(description)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Add error messages
1. If the data file has an incorrect JSON format, tell the user what is missing / incorrect
2. If a task in the data file has a missing field, specify which field is missing (does not specify for which task)

Handle duplicate tasks by skipping them and printing a message informing the user.

Fixes #42 